### PR TITLE
Support For Custom File/Folder Entry Points

### DIFF
--- a/src/uibooster/UiBooster.java
+++ b/src/uibooster/UiBooster.java
@@ -271,6 +271,60 @@ public class UiBooster {
     public File showFileOrDirectorySelection(String description, String... extensions) {
         return FilesystemDialog.showFileOrDirectorySelectionDialog(description, extensions);
     }
+    
+    /**
+     * Shows a file selection dialog starting from a specific directory path. Only files are shown and selectable
+     *
+     * @param path full directory path for opening the dialog box in
+     * @return returns the selection file or null on cancel
+     */
+    public File showFileSelectionFromPath(String path) {
+        return FilesystemDialog.showFileSelectionDialogFromPath(path);
+    }
+    
+    /**
+     * Shows a file selection dialog starting from a specific directory path. Only files are shown and selectable
+     *
+     * @param path full directory path for opening the dialog box in
+     * @param description expects a short and readable description for the extensions
+     * @param extensions  expects one or more allowed extensions without the dot (f.e. bmp, png, pdf)
+     * @return returns the selection file or null on cancel
+     */
+    public File showFileSelectionFromPath(String path, String description, String... extensions) {
+        return FilesystemDialog.showFileSelectionDialogFromPath(path, description, extensions);
+    }
+    
+    /**
+     * Shows a directory selection dialog starting from a specific directory path. Only directories are shown and selectable
+     *
+     * @param path full directory path for opening the dialog box in
+     * @return returns the selection directory or null on cancel
+     */
+    public File showDirectorySelectionFromPath(String path) {
+        return FilesystemDialog.showDirectorySelectionDialogFromPath(path);
+    }
+    
+    /**
+     * Shows a selection dialog for files and directories starting from a specific directory path.
+     *
+     * @param path full directory path for opening the dialog box in
+     * @return returns the selection or null on cancel
+     */
+    public File showFileOrDirectorySelectionFromPath(String path) {
+        return FilesystemDialog.showFileOrDirectorySelectionDialogFromPath(path);
+    }
+    
+    /**
+     * Shows a selection dialog for files and directories starting from a specific directory path.
+     *
+     * @param path full directory path for opening the dialog box in
+     * @param description expects a short and readable description for the extensions
+     * @param extensions  expects one or more allowed extensions without the dot (f.e. bmp, png, pdf)
+     * @return returns the selection or null on cancel
+     */
+    public File showFileOrDirectorySelectionFromPath(String path, String description, String... extensions) {
+        return FilesystemDialog.showFileOrDirectorySelectionDialogFromPath(path, description, extensions);
+    }
 
     /**
      * Shows a login dialog with username and password.

--- a/src/uibooster/components/FilesystemDialog.java
+++ b/src/uibooster/components/FilesystemDialog.java
@@ -28,10 +28,48 @@ public class FilesystemDialog {
     public static File showFileOrDirectorySelectionDialog(String description, String... extensions) {
         return showFsSelectionDialog(FILES_AND_DIRECTORIES, description, extensions);
     }
+    
+    public static File showFileSelectionDialogFromPath(String path) {
+        return showFsSelectionDialogFromPath(path, FILES_ONLY, null, null);
+    }
+    
+    public static File showFileSelectionDialogFromPath(String path, String description, String... extensions) {
+        return showFsSelectionDialogFromPath(path, FILES_ONLY, description, extensions);
+    }
+    
+    public static File showDirectorySelectionDialogFromPath(String path) {
+        return showFsSelectionDialogFromPath(path, JFileChooser.DIRECTORIES_ONLY, null, null);
+    }
+    
+    public static File showFileOrDirectorySelectionDialogFromPath(String path) {
+        return showFsSelectionDialogFromPath(path, FILES_AND_DIRECTORIES, null, null);
+    }
+    
+    public static File showFileOrDirectorySelectionDialogFromPath(String path, String description, String... extensions) {
+        return showFsSelectionDialogFromPath(path, FILES_AND_DIRECTORIES, description, extensions);
+    }
 
     private static File showFsSelectionDialog(int type, String description, String... extensions) {
 
         JFileChooser chooser = new JFileChooser();
+        chooser.setFileSelectionMode(type);
+
+        if ((type == FILES_ONLY || type == FILES_AND_DIRECTORIES) && extensions != null && extensions.length > 0) {
+            chooser.setFileFilter(new FileNameExtensionFilter(description, extensions));
+        }
+
+        int returnVal = chooser.showOpenDialog(null);
+
+        if (returnVal == JFileChooser.APPROVE_OPTION) {
+            return chooser.getSelectedFile();
+        }
+
+        return null;
+    }
+    
+    private static File showFsSelectionDialogFromPath(String path, int type, String description, String... extensions) {
+
+        JFileChooser chooser = new JFileChooser(path);
         chooser.setFileSelectionMode(type);
 
         if ((type == FILES_ONLY || type == FILES_AND_DIRECTORIES) && extensions != null && extensions.length > 0) {


### PR DESCRIPTION
The original code for the File/Folder Dialog Boxes always opened from an inconvenient spot, namely the documents folder.

These changes add support for custom entry points for these Dialog Boxes in the form of:

`booster.showDirectorySelectionFromPath("FULL DIRECTORY PATH");`

To use it for opening files from the project folder or executable use this:

`booster.showFileSelectionFromPath(dataPath("../"));`